### PR TITLE
Configure linters and fix linters issues

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,4 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: 1.16.x
-    - run: make vet
-    - run: make sec
     - run: make lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,10 +20,6 @@ linters:
     - wastedassign
 
 linters-settings:
-  stylecheck:
-    # ST1003: naming linter, e.g. fails on underscores in package names
-    checks: ["all", "-ST1003"]
-
   gci:
     local-prefixes: github.com/evilmartians/redis-proxy
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,32 @@
+# See: https://golangci-lint.run/usage/linters/
+
+linters:
+  enable:
+    - bodyclose
+    - decorder
+    - dupl
+    - errname
+    - gci
+    - gocritic
+    - gofmt
+    - gosec
+    - govet
+    - grouper
+    - misspell
+    - noctx
+    - stylecheck
+    - tenv
+    - unconvert
+    - wastedassign
+
+linters-settings:
+  stylecheck:
+    checks: ["all", "-ST1003"]
+
+  gci:
+    local-prefixes: github.com/evilmartians/redis-proxy
+
+  govet:
+    check-shadowing: true
+    enable-all: true
+    disable: fieldalignment

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,7 @@ linters:
 
 linters-settings:
   stylecheck:
+    # ST1003: naming linter, e.g. fails on underscores in package names
     checks: ["all", "-ST1003"]
 
   gci:

--- a/Makefile
+++ b/Makefile
@@ -32,27 +32,9 @@ run:
 test:
 	go test -count=1 -timeout=30s -race ./...
 
-bin/shadow:
-	@which shadow &> /dev/null || \
-		env GO111MODULE=off go get golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow
-
 bin/golangci-lint:
 	@test -x $$(go env GOPATH)/bin/golangci-lint || \
 		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.39.0
-
-bin/gosec:
-	@test -x $$(go env GOPATH)/bin/gosec || \
-		curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v2.7.0
-
-vet: bin/shadow
-	go vet ./...
-	go vet -vettool=$$(which shadow) ./...
-
-sec: bin/gosec
-	$$(go env GOPATH)/bin/gosec -quiet -confidence=medium -severity=medium  ./...
-
-fmt:
-	go fmt ./...
 
 lint: bin/golangci-lint
 	$$(go env GOPATH)/bin/golangci-lint run

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ test:
 
 bin/golangci-lint:
 	@test -x $$(go env GOPATH)/bin/golangci-lint || \
-		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.39.0
+		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.44.0
 
 lint: bin/golangci-lint
 	$$(go env GOPATH)/bin/golangci-lint run

--- a/internal/confita/prefixed_env/prefixed_env.go
+++ b/internal/confita/prefixed_env/prefixed_env.go
@@ -18,7 +18,7 @@ func NewBackend(prefix string) backend.Backend {
 		if val := os.Getenv(key); val != "" {
 			return []byte(val), nil
 		}
-		key = strings.Replace(strings.ToUpper(key), "-", "_", -1)
+		key = strings.ReplaceAll(strings.ToUpper(key), "-", "_")
 		if val := os.Getenv(key); val != "" {
 			return []byte(val), nil
 		}

--- a/internal/confita/prefixed_env/prefixed_env.go
+++ b/internal/confita/prefixed_env/prefixed_env.go
@@ -1,4 +1,4 @@
-package prefixed_env
+package prefixed_env // nolint:stylecheck
 
 import (
 	"context"

--- a/internal/confita/prefixed_env/prefixed_env_test.go
+++ b/internal/confita/prefixed_env/prefixed_env_test.go
@@ -1,4 +1,4 @@
-package prefixed_env
+package prefixed_env // nolint:stylecheck
 
 import (
 	"context"

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -10,16 +10,16 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/heetch/confita"
+	"github.com/heetch/confita/backend/flags"
+	log "github.com/sirupsen/logrus"
+	"github.com/syossan27/tebata"
+
 	"github.com/evilmartians/redis-proxy/internal/confita/prefixed_env"
 	"github.com/evilmartians/redis-proxy/pkg/config"
 	"github.com/evilmartians/redis-proxy/pkg/multiproxy"
 	"github.com/evilmartians/redis-proxy/pkg/server"
 	"github.com/evilmartians/redis-proxy/pkg/version"
-	"github.com/heetch/confita"
-	"github.com/heetch/confita/backend/flags"
-	"github.com/syossan27/tebata"
-
-	log "github.com/sirupsen/logrus"
 )
 
 // Run configures and initializes the application,
@@ -132,14 +132,13 @@ func initLogger(conf config.Config) error {
 		log.SetOutput(os.Stdout)
 	}
 
-	if conf.LogFormat == "text" {
-		log.SetFormatter(&log.TextFormatter{
-			FullTimestamp: true,
-		})
-	} else if conf.LogFormat == "json" {
+	switch conf.LogFormat {
+	case "text":
+		log.SetFormatter(&log.TextFormatter{FullTimestamp: true})
+	case "json":
 		log.SetFormatter(&log.JSONFormatter{})
-	} else {
-		return fmt.Errorf("Unknown log formatter: %s", conf.LogFormat)
+	default:
+		return fmt.Errorf("unknown log formatter: %s", conf.LogFormat)
 	}
 
 	return nil

--- a/pkg/multiproxy/multiproxy.go
+++ b/pkg/multiproxy/multiproxy.go
@@ -5,8 +5,9 @@ package multiproxy
 import (
 	"io"
 
-	"github.com/evilmartians/redis-proxy/pkg/redis"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/evilmartians/redis-proxy/pkg/redis"
 )
 
 type Proxy struct {

--- a/pkg/multiproxy/session_test.go
+++ b/pkg/multiproxy/session_test.go
@@ -6,9 +6,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/evilmartians/redis-proxy/pkg/redis"
 	"github.com/evilmartians/redis-proxy/test/mocks"
-	"github.com/stretchr/testify/assert"
 )
 
 var (

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -42,7 +42,7 @@ func New(addr string, handler Handler) (*Server, error) {
 	socketType, ok := protocolToSocketType[protocol]
 
 	if !ok {
-		return nil, fmt.Errorf("Unsupported protocol: %s", protocol)
+		return nil, fmt.Errorf("unsupported protocol: %s", protocol)
 	}
 
 	l, err := net.Listen(socketType, hostname)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -34,7 +34,7 @@ func TestNew(t *testing.T) {
 		{
 			"With unsupported protocol",
 			"ftp://127.0.0.1:4321",
-			"Unsupported protocol: ftp",
+			"unsupported protocol: ftp",
 			"",
 		},
 		{
@@ -130,12 +130,12 @@ func connectionHandler(conn net.Conn) {
 			break
 		}
 
-		command := strings.TrimSpace(string(input))
+		command := strings.TrimSpace(input)
 		if command == "STOP" {
 			break
 		}
 
 		result := "ECHO: " + command + "\n"
-		conn.Write([]byte(string(result))) // nolint:errcheck
+		conn.Write([]byte(result)) // nolint:errcheck
 	}
 }


### PR DESCRIPTION
Slightly improved linters in a project:
- Added some non-default **golangci** linters. 
- Updated `golangci-lint` to support new linters.
- Fixed issues, that `golangci-lint` found. 
- Removed explicit targets in Makefile for `go vet`, `gosec`,  and `go fmt`. 